### PR TITLE
Fix issue with empty metadata responses on x-cortex-dependency entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog for the Cortex terraform provider.
 
+## 0.0.8
+
+* Fix issue with empty metadata responses on x-cortex-dependency entities
+
 ## 0.0.7
 
 * Fix issue where `sumo_logic` was improperly required for `slos` block

--- a/internal/provider/catalog_entity_resource_test.go
+++ b/internal/provider/catalog_entity_resource_test.go
@@ -209,6 +209,10 @@ func TestAccCatalogEntityResourceComplete(t *testing.T) {
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "groups.0", "test"),
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "groups.1", "test2"),
 
+					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "dependencies.#", "1"),
+					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "dependencies.0.tag", "manual-test"),
+					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "dependencies.0.description", "for testing"),
+
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "links.#", "1"),
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "links.0.name", "Internal Docs"),
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "links.0.type", "documentation"),
@@ -292,6 +296,13 @@ resource "cortex_catalog_entity" "test" {
       notifications_enabled = true
     }
  ]
+
+  dependencies = [
+    { 
+      tag = "manual-test"
+      description = "for testing"
+    }
+  ]
 
   groups = [
    "test",


### PR DESCRIPTION
Fixes an issue where if `x-cortex-dependencies` is returned empty, or passed _into_ the provider as `dependencies = []`, then it returns an inconsistent state (`null` vs `types.StringVal("{}")`).

