### PR TITLE
INFRA-14133: Add ability to ignore metadata on catalog entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog for the Cortex terraform provider.
 
+## Unreleased
+
+* Add the ability to ignore metadata on a Catalog Entity, allowing it to be managed via API instead
+
 ## 0.0.10
 
 * Better handle empty values for description and type on Catalog Entities

--- a/docs/resources/catalog_entity.md
+++ b/docs/resources/catalog_entity.md
@@ -32,6 +32,7 @@ Catalog Entity
 - `description` (String) Description of the entity visible in the Service or Resource Catalog. Markdown is supported.
 - `git` (Attributes) Git configuration for the entity. (see [below for nested schema](#nestedatt--git))
 - `groups` (List of String) List of groups related to the entity.
+- `ignore_metadata` (Boolean) Whether the entity's custom metadata is managed by Terraform. Defaults to `false`. If set to `true`, the provider will ignore any metadata on the Entity and not persist it to state.
 - `issues` (Attributes) Issue tracking configuration for the entity. (see [below for nested schema](#nestedatt--issues))
 - `links` (Attributes List) List of links related to the entity. (see [below for nested schema](#nestedatt--links))
 - `metadata` (String) Custom metadata for the entity, in JSON format in a string. (Use the `jsonencode` function to convert a JSON object to a string.)

--- a/internal/cortex/catalog_entities.go
+++ b/internal/cortex/catalog_entities.go
@@ -191,6 +191,9 @@ func (c *CatalogEntitiesClient) Upsert(ctx context.Context, req UpsertCatalogEnt
 		Violations: []CatalogEntityViolation{},
 	}
 	apiError := &ApiError{}
+	if req.Info.IgnoreMetadata {
+		req.Info.Metadata = nil
+	}
 
 	// The API requires submitting the request as YAML, so we need to marshal it first.
 	bytes, err := yaml.Marshal(req)

--- a/internal/cortex/integrations.go
+++ b/internal/cortex/integrations.go
@@ -8,16 +8,17 @@ package cortex
 // match the structure of the CatalogEntity struct in other responses.
 // See: https://github.com/cortexapps/solutions/blob/master/examples/yaml/catalog/resource.yaml
 type CatalogEntityData struct {
-	Title        string                    `json:"title" yaml:"title"`
-	Description  string                    `json:"description,omitempty" yaml:"description,omitempty"`
-	Tag          string                    `json:"x-cortex-tag" yaml:"x-cortex-tag"`
-	Type         string                    `json:"x-cortex-type,omitempty" yaml:"x-cortex-type,omitempty"`
-	Definition   map[string]interface{}    `json:"x-cortex-definition,omitempty" yaml:"x-cortex-definition,omitempty"`
-	Owners       []CatalogEntityOwner      `json:"x-cortex-owners,omitempty" yaml:"x-cortex-owners,omitempty"`
-	Groups       []string                  `json:"x-cortex-groups,omitempty" yaml:"x-cortex-groups"` // TODO: is this -groups or -service-groups? docs unclear
-	Links        []CatalogEntityLink       `json:"x-cortex-link,omitempty" yaml:"x-cortex-link,omitempty"`
-	Metadata     map[string]interface{}    `json:"x-cortex-custom-metadata,omitempty" yaml:"x-cortex-custom-metadata,omitempty"`
-	Dependencies []CatalogEntityDependency `json:"x-cortex-dependency,omitempty" yaml:"x-cortex-dependency,omitempty"`
+	Title          string                    `json:"title" yaml:"title"`
+	Description    string                    `json:"description,omitempty" yaml:"description,omitempty"`
+	Tag            string                    `json:"x-cortex-tag" yaml:"x-cortex-tag"`
+	Type           string                    `json:"x-cortex-type,omitempty" yaml:"x-cortex-type,omitempty"`
+	Definition     map[string]interface{}    `json:"x-cortex-definition,omitempty" yaml:"x-cortex-definition,omitempty"`
+	Owners         []CatalogEntityOwner      `json:"x-cortex-owners,omitempty" yaml:"x-cortex-owners,omitempty"`
+	Groups         []string                  `json:"x-cortex-groups,omitempty" yaml:"x-cortex-groups"` // TODO: is this -groups or -service-groups? docs unclear
+	Links          []CatalogEntityLink       `json:"x-cortex-link,omitempty" yaml:"x-cortex-link,omitempty"`
+	IgnoreMetadata bool                      `json:"-"`
+	Metadata       map[string]interface{}    `json:"x-cortex-custom-metadata,omitempty" yaml:"x-cortex-custom-metadata,omitempty"`
+	Dependencies   []CatalogEntityDependency `json:"x-cortex-dependency,omitempty" yaml:"x-cortex-dependency,omitempty"`
 
 	// Various generic integration attributes
 	Alerts         []CatalogEntityAlert        `json:"x-cortex-alerts,omitempty" yaml:"x-cortex-alerts,omitempty"`

--- a/internal/provider/catalog_entity_resource_models.go
+++ b/internal/provider/catalog_entity_resource_models.go
@@ -25,6 +25,7 @@ type CatalogEntityResourceModel struct {
 	Owners         []CatalogEntityOwnerResourceModel `tfsdk:"owners"`
 	Groups         []types.String                    `tfsdk:"groups"`
 	Links          []CatalogEntityLinkResourceModel  `tfsdk:"links"`
+	IgnoreMetadata types.Bool                        `tfsdk:"ignore_metadata"`
 	Metadata       types.String                      `tfsdk:"metadata"`
 	Dependencies   []types.Object                    `tfsdk:"dependencies"`
 	Alerts         []types.Object                    `tfsdk:"alerts"`
@@ -72,6 +73,17 @@ func (o *CatalogEntityResourceModel) ToApiModel(ctx context.Context) cortex.Cata
 		links[i] = link.ToApiModel()
 	}
 	metadata := make(map[string]interface{})
+	if !o.IgnoreMetadata.ValueBool() {
+		if !o.Metadata.IsNull() && !o.Metadata.IsUnknown() && o.Metadata.ValueString() != "" {
+			err := json.Unmarshal([]byte(o.Metadata.ValueString()), &metadata)
+			if err != nil {
+				fmt.Println("Error parsing custom metadata: ", err)
+				metadata = make(map[string]interface{})
+			}
+		} else {
+			metadata = make(map[string]interface{})
+		}
+	}
 	if !o.Metadata.IsNull() && !o.Metadata.IsUnknown() && o.Metadata.ValueString() != "" {
 		err := json.Unmarshal([]byte(o.Metadata.ValueString()), &metadata)
 		if err != nil {
@@ -169,6 +181,7 @@ func (o *CatalogEntityResourceModel) ToApiModel(ctx context.Context) cortex.Cata
 		Owners:         owners,
 		Groups:         groups,
 		Links:          links,
+		IgnoreMetadata: o.IgnoreMetadata.ValueBool(),
 		Metadata:       metadata,
 		Dependencies:   dependencies,
 		Alerts:         alerts,

--- a/internal/provider/catalog_entity_resource_test.go
+++ b/internal/provider/catalog_entity_resource_test.go
@@ -560,3 +560,51 @@ resource "cortex_catalog_entity" "test-resource-simple" {
  })
 }`, tag, name, description)
 }
+
+func TestAccCatalogEntityUnmanagedMetadata(t *testing.T) {
+	tag := "test-unmanaged-metadata"
+	resourceName := "cortex_catalog_entity.test-unmanaged-metadata"
+	name := "Unmanaged Metadata Test Entity"
+	description := "Unmanaged Metadata entity"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccCatalogEntityUnmanagedMetadata(tag, name, description),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tag", tag),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "ignore_metadata", "true"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"metadata",
+					"ignore_metadata",
+				},
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccCatalogEntityUnmanagedMetadata(tag string, name string, description string) string {
+	return fmt.Sprintf(`
+resource "cortex_catalog_entity" "test-unmanaged-metadata" {
+ tag = %[1]q
+ name = %[2]q
+ description = %[3]q
+ ignore_metadata = true
+ metadata = jsonencode({
+  "this": "is",
+  "ignored": true
+ })
+}`, tag, name, description)
+}


### PR DESCRIPTION
## What?

Adds the ability to ignore metadata on a Catalog Entity, allowing it to be managed via API instead.

This allows managing Catalog Entities via terraform, but delegating custom data to outside API clients and integrations.