### PR TITLE
Add support for Slack IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog for the Cortex terraform provider.
 
 ## Unreleased
 
+* Add ability for IDs in `x-cortex-slack` channels
 * Add `x-cortex-coralogix` support
 * Add `x-cortex-k8s` support
 

--- a/docs/resources/catalog_entity.md
+++ b/docs/resources/catalog_entity.md
@@ -516,12 +516,10 @@ Optional:
 <a id="nestedatt--slack--channels"></a>
 ### Nested Schema for `slack.channels`
 
-Required:
-
-- `name` (String) Slack channel name.
-
 Optional:
 
+- `id` (String) Slack channel ID. Either this or name must be set.
+- `name` (String) Slack channel name. Either this or name must be set.
 - `notifications_enabled` (Boolean) Whether the slack channel should receive notifications.
 
 

--- a/internal/cortex/catalog_entity_parser.go
+++ b/internal/cortex/catalog_entity_parser.go
@@ -744,6 +744,7 @@ func (c *CatalogEntityParser) interpolateSlack(entity *CatalogEntityData, slackM
 		for _, channel := range channels {
 			channelMap := channel.(map[string]interface{})
 			entity.Slack.Channels = append(entity.Slack.Channels, CatalogEntitySlackChannel{
+				ID:                   MapFetchToString(channelMap, "id"),
 				Name:                 MapFetchToString(channelMap, "name"),
 				NotificationsEnabled: MapFetch(channelMap, "notificationsEnabled", false).(bool),
 			})

--- a/internal/cortex/integrations.go
+++ b/internal/cortex/integrations.go
@@ -671,12 +671,13 @@ func (o *CatalogEntitySlack) Enabled() bool {
 }
 
 type CatalogEntitySlackChannel struct {
-	Name                 string `json:"name" yaml:"name"`
+	ID                   string `json:"id,omitempty" yaml:"id,omitempty"`
+	Name                 string `json:"name,omitempty" yaml:"name,omitempty"`
 	NotificationsEnabled bool   `json:"notificationsEnabled,omitempty" yaml:"notificationsEnabled,omitempty"`
 }
 
 func (o *CatalogEntitySlackChannel) Enabled() bool {
-	return o.Name != ""
+	return o.Name != "" || o.ID != ""
 }
 
 /***********************************************************************************************************************

--- a/internal/provider/catalog_entity_resource.go
+++ b/internal/provider/catalog_entity_resource.go
@@ -964,9 +964,13 @@ func (r *CatalogEntityResource) Schema(ctx context.Context, req resource.SchemaR
 						Optional:            true,
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
+								"id": schema.StringAttribute{
+									MarkdownDescription: "Slack channel ID. Either this or name must be set.",
+									Optional:            true,
+								},
 								"name": schema.StringAttribute{
-									MarkdownDescription: "Slack channel name.",
-									Required:            true,
+									MarkdownDescription: "Slack channel name. Either this or name must be set.",
+									Optional:            true,
 								},
 								"notifications_enabled": schema.BoolAttribute{
 									MarkdownDescription: "Whether the slack channel should receive notifications.",

--- a/internal/provider/catalog_entity_resource_models.go
+++ b/internal/provider/catalog_entity_resource_models.go
@@ -1973,12 +1973,14 @@ func (o *CatalogEntitySlackResourceModel) FromApiModel(ctx context.Context, diag
 }
 
 type CatalogEntitySlackChannelResourceModel struct {
+	ID                   types.String `tfsdk:"id"`
 	Name                 types.String `tfsdk:"name"`
 	NotificationsEnabled types.Bool   `tfsdk:"notifications_enabled"`
 }
 
 func (o *CatalogEntitySlackChannelResourceModel) AttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
+		"id":                    types.StringType,
 		"name":                  types.StringType,
 		"notifications_enabled": types.BoolType,
 	}
@@ -1986,6 +1988,7 @@ func (o *CatalogEntitySlackChannelResourceModel) AttrTypes() map[string]attr.Typ
 
 func (o *CatalogEntitySlackChannelResourceModel) ToApiModel() cortex.CatalogEntitySlackChannel {
 	return cortex.CatalogEntitySlackChannel{
+		ID:                   o.ID.ValueString(),
 		Name:                 o.Name.ValueString(),
 		NotificationsEnabled: o.NotificationsEnabled.ValueBool(),
 	}
@@ -1993,6 +1996,7 @@ func (o *CatalogEntitySlackChannelResourceModel) ToApiModel() cortex.CatalogEnti
 
 func (o *CatalogEntitySlackChannelResourceModel) FromApiModel(entity *cortex.CatalogEntitySlackChannel) CatalogEntitySlackChannelResourceModel {
 	return CatalogEntitySlackChannelResourceModel{
+		ID:                   types.StringValue(entity.ID),
 		Name:                 types.StringValue(entity.Name),
 		NotificationsEnabled: types.BoolValue(entity.NotificationsEnabled),
 	}


### PR DESCRIPTION
Adds support for using `id` in `x-cortex-slack` channels.