### PR TITLE
Add ability to specify role of member on x-cortex-team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog for the Cortex terraform provider.
 
 ## Unreleased
 
+* Add the ability to pass `role` in `x-cortex-team.members` attributes
 * Add `x-cortex-coralogix` support
 * Add `x-cortex-k8s` support
 

--- a/docs/resources/catalog_entity.md
+++ b/docs/resources/catalog_entity.md
@@ -738,6 +738,7 @@ Required:
 Optional:
 
 - `notifications_enabled` (Boolean) Whether the team member should receive notifications.
+- `role` (String) Role of the team member. Optional.
 
 
 

--- a/internal/cortex/catalog_entity_parser.go
+++ b/internal/cortex/catalog_entity_parser.go
@@ -933,6 +933,7 @@ func (c *CatalogEntityParser) interpolateTeam(entity *CatalogEntityData, teamMap
 			entity.Team.Members = append(entity.Team.Members, CatalogEntityTeamMember{
 				Name:                 MapFetchToString(memberMap, "name"),
 				Email:                MapFetchToString(memberMap, "email"),
+				Role:                 MapFetchToString(memberMap, "role"),
 				NotificationsEnabled: MapFetch(memberMap, "notificationsEnabled", false).(bool),
 			})
 		}

--- a/internal/cortex/integrations.go
+++ b/internal/cortex/integrations.go
@@ -83,6 +83,7 @@ func (o *CatalogEntityTeam) Enabled() bool {
 type CatalogEntityTeamMember struct {
 	Name                 string `json:"name" yaml:"name"`
 	Email                string `json:"email" yaml:"email"`
+	Role                 string `json:"role,omitempty" yaml:"role,omitempty"`
 	NotificationsEnabled bool   `json:"notificationsEnabled" yaml:"notificationsEnabled"`
 }
 

--- a/internal/provider/catalog_entity_resource.go
+++ b/internal/provider/catalog_entity_resource.go
@@ -1042,6 +1042,10 @@ func (r *CatalogEntityResource) Schema(ctx context.Context, req resource.SchemaR
 									MarkdownDescription: "Name of the team member.",
 									Required:            true,
 								},
+								"role": schema.StringAttribute{
+									MarkdownDescription: "Role of the team member. Optional.",
+									Optional:            true,
+								},
 								"notifications_enabled": schema.BoolAttribute{
 									MarkdownDescription: "Whether the team member should receive notifications.",
 									Optional:            true,

--- a/internal/provider/catalog_entity_resource_team_models.go
+++ b/internal/provider/catalog_entity_resource_team_models.go
@@ -81,6 +81,7 @@ func (o *CatalogEntityTeamResourceModel) FromApiModel(ctx context.Context, diagn
 type CatalogEntityTeamMemberResourceModel struct {
 	Name                 types.String `tfsdk:"name"`
 	Email                types.String `tfsdk:"email"`
+	Role                 types.String `tfsdk:"role"`
 	NotificationsEnabled types.Bool   `tfsdk:"notifications_enabled"`
 }
 
@@ -88,6 +89,7 @@ func (o *CatalogEntityTeamMemberResourceModel) AttrTypes() map[string]attr.Type 
 	return map[string]attr.Type{
 		"name":                  types.StringType,
 		"email":                 types.StringType,
+		"role":                  types.StringType,
 		"notifications_enabled": types.BoolType,
 	}
 }
@@ -96,6 +98,7 @@ func (o *CatalogEntityTeamMemberResourceModel) ToApiModel() cortex.CatalogEntity
 	return cortex.CatalogEntityTeamMember{
 		Name:                 o.Name.ValueString(),
 		Email:                o.Email.ValueString(),
+		Role:                 o.Role.ValueString(),
 		NotificationsEnabled: o.NotificationsEnabled.ValueBool(),
 	}
 }
@@ -105,10 +108,15 @@ func (o *CatalogEntityTeamMemberResourceModel) FromApiModel(entity *cortex.Catal
 	if entity.NotificationsEnabled {
 		notificationsEnabled = types.BoolValue(true)
 	}
+	role := types.StringNull()
+	if entity.Role != "" {
+		role = types.StringValue(entity.Role)
+	}
 
 	return CatalogEntityTeamMemberResourceModel{
 		Name:                 types.StringValue(entity.Name),
 		Email:                types.StringValue(entity.Email),
+		Role:                 role,
 		NotificationsEnabled: notificationsEnabled,
 	}
 }

--- a/internal/provider/catalog_entity_resource_team_test.go
+++ b/internal/provider/catalog_entity_resource_team_test.go
@@ -216,8 +216,9 @@ resource "cortex_catalog_entity" %[1]q {
   team = {
     members = [
       {
-        name = "Test"
+        name  = "Test"
         email = "test@cortex.io"
+        role  = "engineering-manager"
       }
     ]
   }


### PR DESCRIPTION
Adds the ability to specify the role of a team member in the `members` block of a team catalog entity.